### PR TITLE
"Request Approval" control removed when ApprovalRequested Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ These are often used to send out email notifications to the alternate party in t
 
 ## Index Support
 In addition, there is an index that is managed as part of this module called "Content Approval Part Index". This could be used in generating lists via the query module. 
+
+### Notes
+* Users without "Publish" permissions and with "Request content approval" in their role will not see the "Publish" button when creating a content item.
+* When a Content Item has been requested for approval by a User, and that user attempts to edit the Content Item, the Save Draft button, and "Request Approval" button will not appear until that Content Item is Approved, Rejected, or marked as "Needs Revised."

--- a/Views/ContentApprovalPart.Edit.ApprovalRequest.cshtml
+++ b/Views/ContentApprovalPart.Edit.ApprovalRequest.cshtml
@@ -4,6 +4,9 @@
 
 <div class="btn-group btn-group-approval">
     <span class="status">Status: @Model.Status</span>
-    <input asp-for="Notes" type="text" class="form-control content-preview-select" placeholder="Note (optional)" />
-    <button class="btn btn-success btn-content-approval" type="submit" name="submit.Save" value="submit.RequestApproval">@T["Request Approval"]</button>
+    @if (Model.Status != Settings.ContentApprovalRequested)
+    {
+        <input asp-for="Notes" type="text" class="form-control content-preview-select" placeholder="Note (optional)" />
+        <button class="btn btn-success btn-content-approval" type="submit" name="submit.Save" value="submit.RequestApproval">@T["Request Approval"]</button>
+    }
 </div>


### PR DESCRIPTION
A check has been added where the "Request Approval" control is removed when the ContentItem has the ApprovalRequested Status. This absolutely ensures that the user cannot make any modifications to the ContentItem until someone with Publish permissions updates the status of said ContentItem.

Also updated the README to account for the new logic added by the previous couple of commits.